### PR TITLE
Update ngDoCheck() in Ranking List Component

### DIFF
--- a/src/main/webapp/src/app/ranking/ranking-list/ranking-list.component.ts
+++ b/src/main/webapp/src/app/ranking/ranking-list/ranking-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, SimpleChanges } from '@angular/core';
 import { HiddenGem } from 'src/app/models/hidden-gem';
 import { AppComponent } from 'src/app/app.component';
 import { LocationService } from '../../location.service';
@@ -12,7 +12,7 @@ import { Location } from 'src/app/models/location';
 })
 export class RankingListComponent implements OnInit {
 
-  hiddenGems! : HiddenGem[];
+  hiddenGems = this.appComponent.hiddenGems;
   location = {} as Location;
 
   constructor(private locationService: LocationService, private appComponent: AppComponent) { }
@@ -25,6 +25,8 @@ export class RankingListComponent implements OnInit {
   }
 
   ngDoCheck() {
-    this.hiddenGems = this.appComponent.hiddenGems;
+    if (this.hiddenGems !== this.appComponent.hiddenGems) {
+      this.hiddenGems = this.appComponent.hiddenGems;
+    }
   }
 }

--- a/src/main/webapp/src/app/ranking/ranking-list/ranking-list.component.ts
+++ b/src/main/webapp/src/app/ranking/ranking-list/ranking-list.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit, SimpleChanges } from '@angular/core';
-import { HiddenGem } from 'src/app/models/hidden-gem';
+import { Component, OnInit } from '@angular/core';
 import { AppComponent } from 'src/app/app.component';
 import { LocationService } from '../../location.service';
 import { Location } from 'src/app/models/location';


### PR DESCRIPTION
ngDoCheck is a hook that "is called with enormous frequency — after every change detection cycle no matter where the change occurred." (source: https://stackoverflow.com/questions/42226191/angular2-component-ngdocheck-is-endlessly-executed)

I didn't realise it previously but it's called endlessly for every single changes that happen in the whole application. To avoid this to happen, I defined a custom change detection for when the hidden gems have been fully retrieved. Now, ngDoCheck is only called once, when the hidden gems have been retrieved.
Source for custom change detection: https://stackoverflow.com/questions/42226191/angular2-component-ngdocheck-is-endlessly-executed