### PR TITLE
Update side nav bar close() function

### DIFF
--- a/src/main/webapp/src/app/nav-bar/nav-bar.component.html
+++ b/src/main/webapp/src/app/nav-bar/nav-bar.component.html
@@ -1,9 +1,9 @@
-  
+
 <mat-toolbar color="primary">
   <mat-toolbar-row>
     <button mat-icon-button>
       <mat-icon (click)="sidenav.toggle()">menu</mat-icon>
-    </button> 
+    </button>
     <h1>Hidden Gems </h1>
     <span class="menu-spacer"></span>
     <div>
@@ -22,7 +22,7 @@
     <mat-nav-list>
       <a mat-list-item routerLink="/home"> Home</a>
       <a mat-list-item routerLink="/recommendation"> Recommendation</a>
-      <a mat-list-item (click)="sidenav.toggle()" href="" mat-list-item>Close</a>
+      <a mat-list-item (click)="sidenav.toggle()" mat-list-item>Close</a>
 
     </mat-nav-list>
   </mat-sidenav>


### PR DESCRIPTION
Bug: when clicking on "close" in the side nav bar, it used to refresh the page and throw a 404 error.
Now: the "close" closes the side nav bar without refreshing the page